### PR TITLE
Optimize PropertyBag for reference types & code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,11 @@ Lets make it flat and simple using transaction_steps
 | Should_Benchmark_IterateAllAsync_Over_Async_Steps | 3.095 us | 0.0261 us | 0.0231 us | 0.4044 |      - |     - |   2.49 KB |
 |   Should_Benchmark_IterateAllAsync_Over_All_Steps | 6.175 us | 0.0448 us | 0.0397 us | 0.5569 | 0.0076 |     - |   3.43 KB |
 
+## PropertyBagTest
+
+|             Method |     Mean |     Error |    StdDev |   Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
+|------------------- |---------:|----------:|----------:|---------:|------:|------:|------:|----------:|
+|     Set_Value_Type | 5.022 us | 0.6291 us | 1.7640 us | 5.300 us |     - |     - |     - |     856 B |
+| Set_Reference_Type | 3.356 us | 0.2597 us | 0.7367 us | 2.900 us |     - |     - |     - |     136 B |
+|     Get_Value_Type | 3.904 us | 0.2187 us | 0.6169 us | 4.050 us |     - |     - |     - |         - |
+| Get_Reference_Type | 2.597 us | 0.1166 us | 0.3030 us | 2.500 us |     - |     - |     - |         - |

--- a/src/Anixe.TransactionSteps/Anixe.TransactionSteps.csproj
+++ b/src/Anixe.TransactionSteps/Anixe.TransactionSteps.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Title>Transaction Steps</Title>
     <Authors>WM</Authors>
   </PropertyGroup>

--- a/src/Anixe.TransactionSteps/IPropertyBag.cs
+++ b/src/Anixe.TransactionSteps/IPropertyBag.cs
@@ -11,5 +11,5 @@ namespace Anixe.TransactionSteps
     void Unset<T>();
     IPropertyBag Clone();
     IPropertyBag Clone(System.Type[] exclude);
-  }  
+  }
 }

--- a/src/Anixe.TransactionSteps/IStep.cs
+++ b/src/Anixe.TransactionSteps/IStep.cs
@@ -13,13 +13,13 @@ namespace Anixe.TransactionSteps
   public interface IStep
   {
     bool CanProcess();
-    bool IsAsync();    
+    bool IsAsync();
     Task ProcessAsync(CancellationToken token);
     void Process();
     IServiceProvider Services { get; set; }
     string Name { get; set; }
-    double TimeTaken { get; set; }    
-    int ProcessedItemsCount { get; set; }    
+    double TimeTaken { get; set; }
+    int ProcessedItemsCount { get; set; }
     LinkedList<IStep> Neighbourood { get; set; }
     LinkedListNode<IStep> Current { get; set; }
     bool WasFired { get; set; }

--- a/src/Anixe.TransactionSteps/IStepIterator.cs
+++ b/src/Anixe.TransactionSteps/IStepIterator.cs
@@ -8,16 +8,16 @@ namespace Anixe.TransactionSteps
   public interface IStepIterator<T> where T : IPropertyBag
   {
     List<StepStat> Stats { get; }
+
     Task<T> IterateAllAsync(
-      IServiceProvider services, 
-      LinkedList<IStep> steps, 
-      IStep errorHandler, 
+      IServiceProvider services,
+      LinkedList<IStep> steps,
+      IStep errorHandler,
       CancellationToken token);
 
     void IterateAll(
-      IServiceProvider services, 
-      LinkedList<IStep> steps, 
+      IServiceProvider services,
+      LinkedList<IStep> steps,
       IStep errorHandler);
-      
   }
 }

--- a/src/Anixe.TransactionSteps/IValueTaskStep.cs
+++ b/src/Anixe.TransactionSteps/IValueTaskStep.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,8 +13,8 @@ namespace Anixe.TransactionSteps
     bool CanProcess();
     ValueTask Process(CancellationToken token);
     string Name { get; set; }
-    double TimeTaken { get; set; }    
-    int ProcessedItemsCount { get; set; }    
+    double TimeTaken { get; set; }
+    int ProcessedItemsCount { get; set; }
     bool WasFired { get; set; }
     bool BreakProcessing { get; set; }
     /// <summary>

--- a/src/Anixe.TransactionSteps/IValueTaskStepIterator.cs
+++ b/src/Anixe.TransactionSteps/IValueTaskStepIterator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Anixe.TransactionSteps/Predefined/AsyncStep.cs
+++ b/src/Anixe.TransactionSteps/Predefined/AsyncStep.cs
@@ -6,38 +6,37 @@ namespace Anixe.TransactionSteps.Predefined
 {
   public class AsyncStep : StepBase, IStep
   {
-    private Func<IStep, Task> action;
-    private Predicate<IStep> canProcessPredicate;
-    
+    private readonly Func<IStep, Task> action;
+    private readonly Predicate<IStep> canProcessPredicate;
 
     public AsyncStep(Func<IStep, Task> action, Predicate<IStep> canProcessPredicate = null)
     {
-      this.action = action;        
-      this.canProcessPredicate = canProcessPredicate ?? True;      
+      this.action = action;
+      this.canProcessPredicate = canProcessPredicate ?? True;
     }
-    
+
     public bool CanProcess()
     {
-        return this.canProcessPredicate(this);
+      return this.canProcessPredicate(this);
     }
 
     public bool IsAsync()
     {
-        return true;
+      return true;
     }
 
     public void Process()
     {
-      throw new NotImplementedException();
+      throw new NotSupportedException();
     }
 
     public async Task ProcessAsync(CancellationToken token)
     {
-      if(token.IsCancellationRequested)
+      if (token.IsCancellationRequested)
       {
         var tcs = new TaskCompletionSource<int>();
         tcs.SetCanceled();
-        await tcs.Task;        
+        await tcs.Task;
       }
       await this.action(this);
     }
@@ -45,6 +44,6 @@ namespace Anixe.TransactionSteps.Predefined
     private bool True(IStep step)
     {
       return true;
-    }        
+    }
   }
 }

--- a/src/Anixe.TransactionSteps/Predefined/CtxStep.cs
+++ b/src/Anixe.TransactionSteps/Predefined/CtxStep.cs
@@ -6,47 +6,44 @@ namespace Anixe.TransactionSteps.Predefined
 {
   public class CtxStep<T> : StepBase<T>, IStep<T> where T : class
   {
-    private Action<IStep<T>> action;
-    private Predicate<IStep<T>> canProcessPredicate;
+    private readonly Action<IStep<T>> action;
+    private readonly Predicate<IStep<T>> canProcessPredicate;
 
     public CtxStep(Action<IStep<T>> action, Predicate<IStep<T>> canProcessPredicate = null)
     {
-      this.action = action;        
+      this.action = action;
       this.canProcessPredicate = canProcessPredicate ?? True;
     }
 
     public bool CanProcess()
     {
-        return this.canProcessPredicate(this);
+      return this.canProcessPredicate(this);
     }
 
     public bool IsAsync()
     {
-        return false;
+      return false;
     }
 
     public void Process()
     {
-      if(this.action != null)
-      {
-        this.action(this);
-      }
+      this.action?.Invoke(this);
     }
 
     public async Task ProcessAsync(CancellationToken token)
     {
-      #if !NET45
+#if !NET45
       await Task.FromException(new NotImplementedException());
-      #else
+#else
       var ctx = new TaskCompletionSource<bool>();
       ctx.SetException(new NotImplementedException());
       await ctx.Task;
-      #endif
+#endif
     }
 
     private bool True(IStep step)
     {
       return true;
-    }    
+    }
   }
 }

--- a/src/Anixe.TransactionSteps/Predefined/CtxValueTaskStep.cs
+++ b/src/Anixe.TransactionSteps/Predefined/CtxValueTaskStep.cs
@@ -6,9 +6,9 @@ namespace Anixe.TransactionSteps.Predefined
 {
   public class CtxValueTaskStep<T> : ValueStepBase<T>, IValueTaskStep<T> where T : class
   {
-    private Action<IValueTaskStep<T>> syncAction;
-    private Func<IValueTaskStep<T>, CancellationToken, Task> asyncAction;
-    private Func<bool> canProcessPredicate;
+    private readonly Action<IValueTaskStep<T>> syncAction;
+    private readonly Func<IValueTaskStep<T>, CancellationToken, Task> asyncAction;
+    private readonly Func<bool> canProcessPredicate;
 
     public CtxValueTaskStep(Action<IValueTaskStep<T>> syncAction, Func<IValueTaskStep<T>, CancellationToken, Task> asyncAction, Func<bool> canProcessPredicate)
     {

--- a/src/Anixe.TransactionSteps/Predefined/Step.cs
+++ b/src/Anixe.TransactionSteps/Predefined/Step.cs
@@ -6,47 +6,44 @@ namespace Anixe.TransactionSteps.Predefined
 {
   public class Step : StepBase, IStep
   {
-    private Action<IStep> action;
-    private Predicate<IStep> canProcessPredicate;
+    private readonly Action<IStep> action;
+    private readonly Predicate<IStep> canProcessPredicate;
 
     public Step(Action<IStep> action, Predicate<IStep> canProcessPredicate = null)
     {
-      this.action = action;        
+      this.action = action;
       this.canProcessPredicate = canProcessPredicate ?? True;
     }
 
     public bool CanProcess()
     {
-        return this.canProcessPredicate(this);
+      return this.canProcessPredicate(this);
     }
 
     public bool IsAsync()
     {
-        return false;
+      return false;
     }
 
     public void Process()
     {
-      if(this.action != null)
-      {
-        this.action(this);
-      }
+      this.action?.Invoke(this);
     }
 
     public async Task ProcessAsync(CancellationToken token)
     {
-      #if !NET45
+#if !NET45
       await Task.FromException(new NotImplementedException());
-      #else
+#else
       var ctx = new TaskCompletionSource<bool>();
       ctx.SetException(new NotImplementedException());
       await ctx.Task;
-      #endif
+#endif
     }
 
     private bool True(IStep step)
     {
       return true;
-    }    
+    }
   }
 }

--- a/src/Anixe.TransactionSteps/Predefined/StepProxy.cs
+++ b/src/Anixe.TransactionSteps/Predefined/StepProxy.cs
@@ -10,12 +10,12 @@ namespace Anixe.TransactionSteps.Predefined
     private readonly AsyncStepBase<T> asyncStep;
     private readonly SyncStepBase<T> step;
 
-    public StepProxyBase(AsyncStepBase<T> asyncStep)
+    protected StepProxyBase(AsyncStepBase<T> asyncStep)
     {
       this.asyncStep = asyncStep;
     }
 
-    public StepProxyBase(SyncStepBase<T> step)
+    protected StepProxyBase(SyncStepBase<T> step)
     {
       this.step = step;
     }
@@ -29,10 +29,10 @@ namespace Anixe.TransactionSteps.Predefined
     {
       this.SyncStep.Process();
     }
-    
+
     public virtual async Task ProcessAsync(CancellationToken token)
-    {      
-      await this.AsyncStep.ProcessAsync(token);      
+    {
+      await this.AsyncStep.ProcessAsync(token);
     }
 
     private IStep<T> InnerStep
@@ -42,12 +42,12 @@ namespace Anixe.TransactionSteps.Predefined
 
     private IStep<T> AsyncStep
     {
-      get { return this.asyncStep as IStep<T>; }
+      get => this.asyncStep as IStep<T>;
     }
 
     private IStep<T> SyncStep
     {
-      get { return this.step as IStep<T>; }
+      get => this.step as IStep<T>;
     }
 
     public bool IsAsync()
@@ -57,62 +57,62 @@ namespace Anixe.TransactionSteps.Predefined
 
     public T Context
     {
-      get { return this.InnerStep.Context; }
-      set { this.InnerStep.Context = value; }
+      get => this.InnerStep.Context;
+      set => this.InnerStep.Context = value;
     }
 
-    public IServiceProvider Services 
-    { 
-      get { return this.InnerStep.Services; }
-      set { this.InnerStep.Services = value; }
+    public IServiceProvider Services
+    {
+      get => this.InnerStep.Services;
+      set => this.InnerStep.Services = value;
     }
 
     public string Name
     {
-      get { return this.InnerStep.Name; }
-      set { this.InnerStep.Name = value; }    
+      get => this.InnerStep.Name;
+      set => this.InnerStep.Name = value;
     }
 
-    public double TimeTaken 
+    public double TimeTaken
     {
-      get { return this.InnerStep.TimeTaken; }
-      set { this.InnerStep.TimeTaken = value; }    
+      get => this.InnerStep.TimeTaken;
+      set => this.InnerStep.TimeTaken = value;
     }
 
     public int ProcessedItemsCount
     {
-      get { return this.InnerStep.ProcessedItemsCount; }
-      set { this.InnerStep.ProcessedItemsCount = value; }    
+      get => this.InnerStep.ProcessedItemsCount;
+      set => this.InnerStep.ProcessedItemsCount = value;
     }
-        
+
     public LinkedList<IStep> Neighbourood
     {
-      get { return this.InnerStep.Neighbourood; }
-      set { this.InnerStep.Neighbourood = value; }    
+      get => this.InnerStep.Neighbourood;
+      set => this.InnerStep.Neighbourood = value;
     }
-    
+
     public LinkedListNode<IStep> Current
     {
-      get { return this.InnerStep.Current; }
-      set { this.InnerStep.Current = value; }    
+      get => this.InnerStep.Current;
+      set => this.InnerStep.Current = value;
     }
-    
+
     public bool WasFired
     {
-      get { return this.InnerStep.WasFired; }
-      set { this.InnerStep.WasFired = value; }    
+      get => this.InnerStep.WasFired;
+      set => this.InnerStep.WasFired = value;
     }
-    
+
     public bool BreakProcessing
     {
-      get { return this.InnerStep.BreakProcessing; }
-      set { this.InnerStep.BreakProcessing = value; }    
+      get => this.InnerStep.BreakProcessing;
+      set => this.InnerStep.BreakProcessing = value;
     }
 
     public bool MustProcessAfterCancel
     {
-      get { return this.InnerStep.MustProcessAfterCancel; }
-      set { this.InnerStep.MustProcessAfterCancel = value; }    
-    }    
+      get => this.InnerStep.MustProcessAfterCancel;
+      set => this.InnerStep.MustProcessAfterCancel = value;
+    }
   }
 }

--- a/src/Anixe.TransactionSteps/Predefined/StepStatProxy.cs
+++ b/src/Anixe.TransactionSteps/Predefined/StepStatProxy.cs
@@ -6,22 +6,22 @@ namespace Anixe.TransactionSteps.Predefined
 {
   public abstract class StepStatProxy<T> : StepProxyBase<T> where T : class
   {
-    public StepStatProxy(AsyncStepBase<T> asyncStep) : base(asyncStep) { }
+    protected StepStatProxy(AsyncStepBase<T> asyncStep) : base(asyncStep) { }
 
-    public StepStatProxy(SyncStepBase<T> step) : base(step) { }
-    
+    protected StepStatProxy(SyncStepBase<T> step) : base(step) { }
+
     public override void Process()
     {
-      var dt = DateTime.UtcNow;      
+      var dt = DateTime.UtcNow;
       base.Process();
       var tt = (DateTime.UtcNow - dt).TotalMilliseconds;
-      this.TimeTaken = tt;      
+      this.TimeTaken = tt;
     }
 
     public override async Task ProcessAsync(CancellationToken token)
-    {      
-      var dt = DateTime.UtcNow;      
-      await base.ProcessAsync(token);      
+    {
+      var dt = DateTime.UtcNow;
+      await base.ProcessAsync(token);
       var tt = (DateTime.UtcNow - dt).TotalMilliseconds;
       this.TimeTaken = tt;
     }

--- a/src/Anixe.TransactionSteps/PropertyBag.cs
+++ b/src/Anixe.TransactionSteps/PropertyBag.cs
@@ -9,86 +9,74 @@ namespace Anixe.TransactionSteps
     public override void Set<T>(T property)
     {
       var type = typeof(T);
-      this.typedProperties.Add(type, new PropertyBagItem<T>(property));
+      this.typedProperties.Add(type, property);
     }
 
     public override void Set<T>(string name, T property)
     {
-      this.namedProperties.Add(name, new PropertyBagItem<T>(property));
+      this.namedProperties.Add(name, property);
     }
   }
 
   public class PropertyBag : IPropertyBag
   {
-    protected class PropertyBagItem
-    {
-    }
-
-    protected class PropertyBagItem<T> : PropertyBagItem
-    {
-      private readonly T instance;
-      public PropertyBagItem(T instance)
-      {
-        this.instance = instance;
-      }
-
-      public T Value => this.instance;
-    }
-
-    protected readonly Dictionary<Type, PropertyBagItem> typedProperties;
-    protected readonly Dictionary<string, PropertyBagItem> namedProperties;
+    protected readonly Dictionary<Type, object> typedProperties;
+    protected readonly Dictionary<string, object> namedProperties;
 
     public PropertyBag()
     {
-      this.typedProperties = new Dictionary<Type, PropertyBagItem>();
-      this.namedProperties = new Dictionary<string, PropertyBagItem>();
+      this.typedProperties = new Dictionary<Type, object>();
+      this.namedProperties = new Dictionary<string, object>();
     }
 
-    private PropertyBag(Dictionary<Type, PropertyBagItem> typedProperties, Dictionary<string, PropertyBagItem> namedProperties)
+    private PropertyBag(IEnumerable<KeyValuePair<Type, object>> typedProperties, Dictionary<string, object> namedProperties)
     {
-      this.typedProperties = new Dictionary<Type, PropertyBagItem>(typedProperties);
-      this.namedProperties = new Dictionary<string, PropertyBagItem>(namedProperties);
+      this.namedProperties = new Dictionary<string, object>(namedProperties);
+      this.typedProperties = new Dictionary<Type, object>();
+      foreach (var prop in typedProperties)
+      {
+        this.typedProperties.Add(prop.Key, prop.Value);
+      }
     }
 
     public bool Contains<T>()
     {
-      return TryGet<T>() != null;
+      return this.typedProperties.ContainsKey(typeof(T));
     }
 
     public bool Contains<T>(string name)
     {
-      return TryGet<T>(name) != null;
+      return this.namedProperties.ContainsKey(name);
     }
 
     public virtual void Set<T>(T property)
     {
       var type = typeof(T);
-      this.typedProperties[type] = new PropertyBagItem<T>(property);
+      this.typedProperties[type] = property;
     }
 
     public virtual void Set<T>(string name, T property)
     {
-      this.namedProperties[name] = new PropertyBagItem<T>(property);
+      this.namedProperties[name] = property;
     }
 
     public T Get<T>()
     {
-      var retval = TryGet<T>();
-      if (retval != null)
+      var type = typeof(T);
+      if (this.typedProperties.TryGetValue(type, out var item))
       {
-        return retval.Value;
+        return (T)item;
       }
-      return default(T);
+      return default;
     }
 
     public T Get<T>(string name)
     {
-      var retval = TryGet<T>(name);
-      if (retval != null)
+      if (this.namedProperties.TryGetValue(name, out var item))
       {
-        return retval.Value;
+        return (T)item;
       }
-      return default(T);
+      return default;
     }
 
     public void Unset<T>()
@@ -104,30 +92,11 @@ namespace Anixe.TransactionSteps
 
     public IPropertyBag Clone(Type[] exclude)
     {
-      var cloned = this.typedProperties.Where(kvp => Array.Find(exclude, item => item == kvp.Key) == default).ToDictionary(g => g.Key, g => g.Value);
+      var cloned = this.typedProperties.Where(kvp => !Array.Exists(exclude, item => item == kvp.Key));
       return new PropertyBag(
         cloned,
         this.namedProperties
       );
-    }
-
-    private PropertyBagItem<T> TryGet<T>()
-    {
-      var type = typeof(T);
-      if (this.typedProperties.TryGetValue(type, out var item))
-      {
-        return (PropertyBagItem<T>)item;
-      }
-      return null;
-    }
-
-    private PropertyBagItem<T> TryGet<T>(string name)
-    {
-      if (this.namedProperties.TryGetValue(name, out var item))
-      {
-        return (PropertyBagItem<T>)item;
-      }
-      return null;
     }
   }
 }

--- a/src/Anixe.TransactionSteps/PropertyBag.cs
+++ b/src/Anixe.TransactionSteps/PropertyBag.cs
@@ -14,8 +14,8 @@ namespace Anixe.TransactionSteps
 
     public override void Set<T>(string name, T property)
     {
-      this.namedProperties.Add(name, new PropertyBagItem<T>(property));       
-    }        
+      this.namedProperties.Add(name, new PropertyBagItem<T>(property));
+    }
   }
 
   public class PropertyBag : IPropertyBag
@@ -23,7 +23,7 @@ namespace Anixe.TransactionSteps
     protected class PropertyBagItem
     {
     }
-    
+
     protected class PropertyBagItem<T> : PropertyBagItem
     {
       private readonly T instance;
@@ -32,12 +32,9 @@ namespace Anixe.TransactionSteps
         this.instance = instance;
       }
 
-      public T Value
-      {
-        get { return this.instance; }
-      }
-    }  
-    
+      public T Value => this.instance;
+    }
+
     protected readonly Dictionary<Type, PropertyBagItem> typedProperties;
     protected readonly Dictionary<string, PropertyBagItem> namedProperties;
 
@@ -67,40 +64,37 @@ namespace Anixe.TransactionSteps
     {
       var type = typeof(T);
       this.typedProperties[type] = new PropertyBagItem<T>(property);
-    }    
+    }
 
     public virtual void Set<T>(string name, T property)
     {
-      this.namedProperties[name] = new PropertyBagItem<T>(property);       
+      this.namedProperties[name] = new PropertyBagItem<T>(property);
     }
 
     public T Get<T>()
     {
       var retval = TryGet<T>();
-      if(retval != null)
+      if (retval != null)
       {
         return retval.Value;
       }
-      return default(T);      
+      return default(T);
     }
 
     public T Get<T>(string name)
     {
       var retval = TryGet<T>(name);
-      if(retval != null)
+      if (retval != null)
       {
         return retval.Value;
       }
-      return default(T);      
+      return default(T);
     }
 
     public void Unset<T>()
     {
       var type = typeof(T);
-      if(this.typedProperties.ContainsKey(type))
-      {
-        this.typedProperties.Remove(type);
-      }      
+      this.typedProperties.Remove(type);
     }
 
     public IPropertyBag Clone()
@@ -110,9 +104,9 @@ namespace Anixe.TransactionSteps
 
     public IPropertyBag Clone(Type[] exclude)
     {
-      var cloned = this.typedProperties.Where(kvp => !exclude.Any(item => item == kvp.Key)).ToDictionary(g => g.Key, g => g .Value);
+      var cloned = this.typedProperties.Where(kvp => Array.Find(exclude, item => item == kvp.Key) == default).ToDictionary(g => g.Key, g => g.Value);
       return new PropertyBag(
-        cloned, 
+        cloned,
         this.namedProperties
       );
     }
@@ -120,20 +114,18 @@ namespace Anixe.TransactionSteps
     private PropertyBagItem<T> TryGet<T>()
     {
       var type = typeof(T);
-      PropertyBagItem instance = null; 
-      if(this.typedProperties.TryGetValue(type, out instance))
+      if (this.typedProperties.TryGetValue(type, out var item))
       {
-        return ((PropertyBagItem<T>)instance);
+        return (PropertyBagItem<T>)item;
       }
       return null;
     }
-         
+
     private PropertyBagItem<T> TryGet<T>(string name)
     {
-      PropertyBagItem instance = null; 
-      if(this.namedProperties.TryGetValue(name, out instance))
+      if (this.namedProperties.TryGetValue(name, out var item))
       {
-        return ((PropertyBagItem<T>)instance);
+        return (PropertyBagItem<T>)item;
       }
       return null;
     }

--- a/src/Anixe.TransactionSteps/StepBase.cs
+++ b/src/Anixe.TransactionSteps/StepBase.cs
@@ -7,10 +7,7 @@ namespace Anixe.TransactionSteps
 {
   public abstract class AsyncStepBase<T> : StepBase<T> where T : class
   {
-    public bool IsAsync()
-    {
-      return true;
-    }
+    public bool IsAsync() => true;
     public void Process()
     {
       throw new NotImplementedException();
@@ -19,46 +16,41 @@ namespace Anixe.TransactionSteps
 
   public abstract class SyncStepBase<T> : StepBase<T> where T : class
   {
-    public bool IsAsync()
-    {
-      return false;
-    }
+    public bool IsAsync() => false;
     public Task ProcessAsync(CancellationToken token)
     {
       throw new NotImplementedException();
     }
   }
-  
+
   public abstract class StepBase<T> : StepBase where T : class
   {
-    public T Context
-    {
-      get;
-      set;
-    }
+    public T Context { get; set; }
   }
 
   public abstract class StepBase
   {
     private string stepName;
     public IServiceProvider Services { get; set; }
-    public string Name 
-    { 
-      get 
+
+    public string Name
+    {
+      get
       {
-        if(string.IsNullOrEmpty(this.stepName))
+        if (string.IsNullOrEmpty(this.stepName))
         {
           this.stepName = GetDefaultStepName();
         }
         return this.stepName;
-      } 
+      }
       set
       {
         this.stepName = value;
-      } 
+      }
     }
+
     public double TimeTaken { get; set; }
-    public int ProcessedItemsCount { get; set; }    
+    public int ProcessedItemsCount { get; set; }
     public LinkedList<IStep> Neighbourood { get; set; }
     public LinkedListNode<IStep> Current { get; set; }
     public bool WasFired { get; set; }
@@ -68,6 +60,6 @@ namespace Anixe.TransactionSteps
     private string GetDefaultStepName()
     {
       return this.GetType().Name;
-    }            
+    }
   }
 }

--- a/src/Anixe.TransactionSteps/StepIterator.cs
+++ b/src/Anixe.TransactionSteps/StepIterator.cs
@@ -10,15 +10,12 @@ namespace Anixe.TransactionSteps
     private readonly T context;
     private readonly List<StepStat> stats;
 
-    public List<StepStat> Stats
-    {
-      get { return this.stats; }
-    }
+    public List<StepStat> Stats => this.stats;
 
     public StepIterator(T context)
     {
       this.context = context;
-      this.stats = new List<StepStat> { };
+      this.stats = new List<StepStat>();
     }
 
     public async Task<T> IterateAllAsync(
@@ -81,18 +78,11 @@ namespace Anixe.TransactionSteps
           currentNode = currentNode.Next;
         }
       }
-      catch (Exception ex)
+      catch (Exception ex) when (errorHandler != null)
       {
-        if (errorHandler != null)
-        {
-          this.context.Set<Exception>(ex);
-          errorHandler.Services = services;
-          ExecuteStep(errorHandler);
-        }
-        else
-        {
-          throw;
-        }
+        this.context.Set<Exception>(ex);
+        errorHandler.Services = services;
+        ExecuteStep(errorHandler);
       }
     }
 
@@ -107,9 +97,9 @@ namespace Anixe.TransactionSteps
 
     private async Task ExecuteStepAsync(IStep step, CancellationToken token)
     {
-      if (step is IStep<T>)
+      if (step is IStep<T> stepGeneric)
       {
-        ((IStep<T>)step).Context = this.context;
+        stepGeneric.Context = this.context;
       }
 
       var dt = DateTime.UtcNow;
@@ -132,9 +122,9 @@ namespace Anixe.TransactionSteps
 
     private void ExecuteStep(IStep step)
     {
-      if (step is IStep<T>)
+      if (step is IStep<T> stepGeneric)
       {
-        ((IStep<T>)step).Context = this.context;
+        stepGeneric.Context = this.context;
       }
 
       if (step.CanProcess())

--- a/src/Anixe.TransactionSteps/StepStat.cs
+++ b/src/Anixe.TransactionSteps/StepStat.cs
@@ -11,8 +11,8 @@ namespace Anixe.TransactionSteps
       return new StepStat
       {
         Name = step.Name,
-        TimeTaken = step.TimeTaken,    
-        ProcessedItemsCount = step.ProcessedItemsCount,        
+        TimeTaken = step.TimeTaken,
+        ProcessedItemsCount = step.ProcessedItemsCount,
       };
     }
 

--- a/src/Anixe.TransactionSteps/ValueStepBase.cs
+++ b/src/Anixe.TransactionSteps/ValueStepBase.cs
@@ -1,26 +1,18 @@
-using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Sources;
 
 namespace Anixe.TransactionSteps
 {
-  
   public abstract class ValueStepBase<T> : ValueStepBase
   {
-    public T Context
-    {
-      get;
-      set;
-    }
+    public T Context { get; set; }
   }
 
   public abstract class ValueStepBase : IValueTaskStep
   {
     public virtual ValueTask Process(CancellationToken token)
     {
-      if(IsAsync())
+      if (IsAsync())
       {
         return new ValueTask(ProceeAsync(token));
       }
@@ -36,23 +28,23 @@ namespace Anixe.TransactionSteps
     public abstract bool CanProcess();
 
     private string stepName;
-    public string Name 
-    { 
-      get 
+    public string Name
+    {
+      get
       {
-        if(string.IsNullOrEmpty(this.stepName))
+        if (string.IsNullOrEmpty(this.stepName))
         {
           this.stepName = GetDefaultStepName();
         }
         return this.stepName;
-      } 
+      }
       set
       {
         this.stepName = value;
-      } 
+      }
     }
     public double TimeTaken { get; set; }
-    public int ProcessedItemsCount { get; set; }    
+    public int ProcessedItemsCount { get; set; }
     public bool WasFired { get; set; }
     public bool BreakProcessing { get; set; }
     public bool MustProcessAfterCancel { get; set; } = false;

--- a/test/Anixe.TransactionSteps.Benchmark/PropertyBagTest.cs
+++ b/test/Anixe.TransactionSteps.Benchmark/PropertyBagTest.cs
@@ -1,0 +1,65 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+
+namespace Anixe.TransactionSteps.Benchmark
+{
+  public class PropertyBagTest
+  {
+    private IPropertyBag subject;
+    private object obj = new object();
+
+    [IterationSetup]
+    public void IterationSetup()
+      => this.subject = new PropertyBag();
+
+    [IterationSetup(Target = nameof(Get_Value_Type))]
+    public void Get_Value_Type_Setup()
+    {
+      IterationSetup();
+      this.subject.Set<int>(1);
+    }
+
+    [IterationSetup(Target = nameof(Get_Reference_Type))]
+    public void Get_Reference_Type_Setup()
+    {
+      IterationSetup();
+      this.subject.Set<string>("1");
+    }
+
+    [Benchmark]
+    public void Set_Value_Type()
+    {
+      for (int i = 0; i < 30; i++)
+      {
+        subject.Set<int>(i);
+      }
+    }
+
+    [Benchmark]
+    public void Set_Reference_Type()
+    {
+      for (int i = 0; i < 30; i++)
+      {
+        subject.Set<object>(this.obj);
+      }
+    }
+
+    [Benchmark]
+    public void Get_Value_Type()
+    {
+      for (int i = 0; i < 30; i++)
+      {
+        subject.Get<int>();
+      }
+    }
+
+    [Benchmark]
+    public void Get_Reference_Type()
+    {
+      for (int i = 0; i < 30; i++)
+      {
+        subject.Get<string>();
+      }
+    }
+  }
+}

--- a/test/Anixe.TransactionSteps.Test/PropertyBagTest.cs
+++ b/test/Anixe.TransactionSteps.Test/PropertyBagTest.cs
@@ -5,7 +5,7 @@ namespace Anixe.TransactionSteps.Test
 {
   public class PropertyBagTest
   {
-    private IPropertyBag subject;
+    private readonly IPropertyBag subject;
 
     public PropertyBagTest()
     {
@@ -44,6 +44,5 @@ namespace Anixe.TransactionSteps.Test
       var actual = subject.Get<int>();
       Assert.Equal(item, actual);
     }
-
   }
 }

--- a/test/Anixe.TransactionSteps.Test/StepIteratorTest.cs
+++ b/test/Anixe.TransactionSteps.Test/StepIteratorTest.cs
@@ -10,30 +10,29 @@ namespace Anixe.TransactionSteps.Test
 {
   public class StepIteratorTest
   {
-    private PropertyBag ctx;
-    private LinkedList<IStep> steps;
-    private StepIterator<IPropertyBag> subject;
+    private readonly PropertyBag ctx;
+    private readonly LinkedList<IStep> steps;
+    private readonly StepIterator<IPropertyBag> subject;
 
     public StepIteratorTest()
     {
-      this.ctx = new PropertyBag{};
+      this.ctx = new PropertyBag();
       this.steps = CreateSteps();
-      this.subject = new StepIterator<IPropertyBag>(ctx);      
+      this.subject = new StepIterator<IPropertyBag>(ctx);
     }
-
 
     public LinkedList<IStep> CreateSteps()
     {
       return new LinkedList<IStep>
       (
         new List<IStep>
-        { 
-          new CtxStep<IPropertyBag>((_) => {  }, (_) => { return true; }),
-          new CtxStep<IPropertyBag>((_) => {  }, (_) => { return true; }),
+        {
+          new CtxStep<IPropertyBag>((_) => {  }, (_) => true),
+          new CtxStep<IPropertyBag>((_) => {  }, (_) => true),
         }
       );
     }
-      
+
     [Fact]
     public async Task Should_IterateAllAsync_Over_All_Steps()
     {
@@ -51,7 +50,7 @@ namespace Anixe.TransactionSteps.Test
     [Fact]
     public async Task Should_IterateAllAsync_Over_Steps_Which_Can_Process()
     {
-      steps.AddFirst(new CtxStep<IPropertyBag>((_) => {  }, (_) => { return false; }));
+      steps.AddFirst(new CtxStep<IPropertyBag>((_) => { }, (_) => false));
       await this.subject.IterateAllAsync(null, steps, null, new CancellationToken());
       Assert.False(steps.All(s => s.WasFired));
       Assert.Equal(2, steps.Where(s => s.WasFired).Count());
@@ -60,7 +59,7 @@ namespace Anixe.TransactionSteps.Test
     [Fact]
     public void Should_IterateAll_Over_Steps_Which_Can_Process()
     {
-      steps.AddFirst(new CtxStep<IPropertyBag>((_) => {  }, (_) => { return false; }));
+      steps.AddFirst(new CtxStep<IPropertyBag>((_) => { }, (_) => false));
       this.subject.IterateAll(null, steps, null);
       Assert.False(steps.All(s => s.WasFired));
       Assert.Equal(2, steps.Where(s => s.WasFired).Count());
@@ -69,23 +68,23 @@ namespace Anixe.TransactionSteps.Test
     [Fact]
     public async Task Should_Not_IterateAllAsync_Over_Steps_After_Cancel()
     {
-      using(var cts = new CancellationTokenSource())
+      using (var cts = new CancellationTokenSource())
       {
-        steps.AddLast(new CtxStep<IPropertyBag>((_) => { cts.Cancel(); }, (_) => { return true; }));
-        steps.AddLast(new CtxStep<IPropertyBag>((_) => {   }, (_) => { return true; }));
+        steps.AddLast(new CtxStep<IPropertyBag>((_) => cts.Cancel(), (_) => true));
+        steps.AddLast(new CtxStep<IPropertyBag>((_) => { }, (_) => true));
         await this.subject.IterateAllAsync(null, steps, null, cts.Token);
         Assert.False(steps.All(s => s.WasFired));
-        Assert.Equal(3, steps.Where(s => s.WasFired).Count());
+        Assert.Equal(3, steps.Count(s => s.WasFired));
       }
     }
-    
+
     [Fact]
     public async Task Should_IterateAllAsync_Over_MustProcessAfterCancel_Steps_After_Cancel()
     {
-      using(var cts = new CancellationTokenSource())
+      using (var cts = new CancellationTokenSource())
       {
-        steps.AddLast(new CtxStep<IPropertyBag>((_) => { cts.Cancel(); }, (_) => { return true; }));
-        steps.AddLast(new CtxStep<IPropertyBag>((_) => {   }, (_) => { return true; }){ MustProcessAfterCancel = true });
+        steps.AddLast(new CtxStep<IPropertyBag>((_) => cts.Cancel(), (_) => true));
+        steps.AddLast(new CtxStep<IPropertyBag>((_) => { }, (_) => true) { MustProcessAfterCancel = true });
         await this.subject.IterateAllAsync(null, steps, null, cts.Token);
         Assert.True(steps.All(s => s.WasFired));
       }
@@ -94,20 +93,19 @@ namespace Anixe.TransactionSteps.Test
     [Fact]
     public async Task Should_Fire_ErrorAsync_Handler_On_Excepton()
     {
-      var errorHandler = new CtxStep<IPropertyBag>((s) => { Assert.True(s.Context.Contains<Exception>()); }, (_) => { return true; });
-      steps.AddFirst(new CtxStep<IPropertyBag>((_) => {  throw new InvalidOperationException("test"); }, (_) => { return true; }));
+      var errorHandler = new CtxStep<IPropertyBag>((s) => Assert.True(s.Context.Contains<Exception>()), (_) => true);
+      steps.AddFirst(new CtxStep<IPropertyBag>((_) => throw new InvalidOperationException("test"), (_) => true));
       await this.subject.IterateAllAsync(null, steps, errorHandler, new CancellationToken());
       Assert.True(errorHandler.WasFired);
-    }    
+    }
 
     [Fact]
     public void Should_Fire_Error_Handler_On_Excepton()
     {
-      var errorHandler = new CtxStep<IPropertyBag>((s) => { Assert.True(s.Context.Contains<Exception>()); }, (_) => { return true; });
-      steps.AddFirst(new CtxStep<IPropertyBag>((_) => {  throw new InvalidOperationException("test"); }, (_) => { return true; }));
+      var errorHandler = new CtxStep<IPropertyBag>((s) => Assert.True(s.Context.Contains<Exception>()), (_) => true);
+      steps.AddFirst(new CtxStep<IPropertyBag>((_) => throw new InvalidOperationException("test"), (_) => true));
       this.subject.IterateAll(null, steps, errorHandler);
       Assert.True(errorHandler.WasFired);
-    }    
-    
+    }
   }
 }

--- a/test/Anixe.TransactionSteps.Test/ValueTaskStepIteratorTest.cs
+++ b/test/Anixe.TransactionSteps.Test/ValueTaskStepIteratorTest.cs
@@ -11,16 +11,15 @@ namespace Anixe.TransactionSteps.Test
 {
   public class ValueTaskStepIteratorTest
   {
-    private PropertyBag ctx;
-    private ValueTaskStepIterator<IPropertyBag> subject;
+    private readonly PropertyBag ctx;
+    private readonly ValueTaskStepIterator<IPropertyBag> subject;
 
     public ValueTaskStepIteratorTest()
     {
-      this.ctx = new PropertyBag { };
+      this.ctx = new PropertyBag();
       this.ctx.Set<Tuple<int>>(Tuple.Create(0));
       this.subject = new ValueTaskStepIterator<IPropertyBag>();
     }
-
 
     public List<IValueTaskStep> CreateSyncSteps()
     {
@@ -30,7 +29,7 @@ namespace Anixe.TransactionSteps.Test
         {
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + 1;
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
-        }, canProcessPredicate: () => { return true; }),
+        }, canProcessPredicate: () => true),
         new CtxValueTaskStep<IPropertyBag>(asyncAction: null, syncAction: (ctx) =>
         {
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + 1;
@@ -49,13 +48,13 @@ namespace Anixe.TransactionSteps.Test
           var val = await File.ReadAllTextAsync(path);
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + int.Parse(val);
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
-        }, syncAction: null, canProcessPredicate: () => { return true; }),
+        }, syncAction: null, canProcessPredicate: () => true),
         new CtxValueTaskStep<IPropertyBag>(asyncAction: async (ctx, token) =>
         {
           var val = await File.ReadAllTextAsync(path);
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + int.Parse(val);
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
-        }, syncAction: null, canProcessPredicate: () => { return true; }),
+        }, syncAction: null, canProcessPredicate: () => true),
       };
     }
 
@@ -70,13 +69,13 @@ namespace Anixe.TransactionSteps.Test
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + int.Parse(val);
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
           cts.Cancel();
-        }, syncAction: null, canProcessPredicate: () => { return true; }),
+        }, syncAction: null, canProcessPredicate: () => true),
         new CtxValueTaskStep<IPropertyBag>(asyncAction: async (ctx, token) =>
         {
           var val = await File.ReadAllTextAsync(path);
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + int.Parse(val);
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
-        }, syncAction: null, canProcessPredicate: () => { return true; }) { MustProcessAfterCancel = mustProcess },
+        }, syncAction: null, canProcessPredicate: () => true) { MustProcessAfterCancel = mustProcess },
       };
     }
 
@@ -90,13 +89,13 @@ namespace Anixe.TransactionSteps.Test
           var val = await File.ReadAllTextAsync("bllaaach");
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + int.Parse(val);
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
-        }, syncAction: null, canProcessPredicate: () => { return true; }),
+        }, syncAction: null, canProcessPredicate: () => true),
         new CtxValueTaskStep<IPropertyBag>(asyncAction: async (ctx, token) =>
         {
           var val = await File.ReadAllTextAsync(path);
           var idx =  ctx.Context.Get<Tuple<int>>().Item1 + int.Parse(val);
           ctx.Context.Set<Tuple<int>>(Tuple.Create(idx));
-        }, syncAction: null, canProcessPredicate: () => { return true; }),
+        }, syncAction: null, canProcessPredicate: () => true),
       };
     }
 
@@ -133,7 +132,7 @@ namespace Anixe.TransactionSteps.Test
     [Fact]
     public async Task Should_IterateAllAsync_Over_Async_Steps_Which_Must_Not_Process_After_Cancel()
     {
-      using(var cts = new CancellationTokenSource())
+      using (var cts = new CancellationTokenSource())
       {
         var steps = CreateAyncSteps(cts, mustProcess: false);
         await this.subject.IterateAllAsync(this.ctx, steps, cts.Token);
@@ -146,7 +145,7 @@ namespace Anixe.TransactionSteps.Test
     public void Should_Throw_Exception_Which_Occurred_In_Step()
     {
       var steps = CreateAyncStepsThrowEx();
-      Assert.ThrowsAsync<InvalidOperationException>(async () => { await this.subject.IterateAllAsync(this.ctx, steps, CancellationToken.None);});
+      Assert.ThrowsAsync<InvalidOperationException>(async () => await this.subject.IterateAllAsync(this.ctx, steps, CancellationToken.None));
     }
   }
 }


### PR DESCRIPTION
It looks that it is more efficient to use boxing of value types instead of always wrapping value with PropertyBagItem class. 

Before change:
```
|             Method |     Mean |     Error |    StdDev |   Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|------:|------:|------:|----------:|
|     Set_Value_Type | 3.976 us | 0.5293 us | 1.4754 us | 3.100 us |     - |     - |     - |     856 B |
| Set_Reference_Type | 4.553 us | 0.5825 us | 1.6713 us | 3.550 us |     - |     - |     - |     856 B |
|     Get_Value_Type | 4.290 us | 0.1211 us | 0.3455 us | 4.300 us |     - |     - |     - |         - |
| Get_Reference_Type | 4.687 us | 0.0993 us | 0.2361 us | 4.700 us |     - |     - |     - |         - |
```

After change:
```
|             Method |     Mean |     Error |    StdDev |   Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|------:|------:|------:|----------:|
|     Set_Value_Type | 5.022 us | 0.6291 us | 1.7640 us | 5.300 us |     - |     - |     - |     856 B |
| Set_Reference_Type | 3.356 us | 0.2597 us | 0.7367 us | 2.900 us |     - |     - |     - |     136 B |
|     Get_Value_Type | 3.904 us | 0.2187 us | 0.6169 us | 4.050 us |     - |     - |     - |         - |
| Get_Reference_Type | 2.597 us | 0.1166 us | 0.3030 us | 2.500 us |     - |     - |     - |         - |
```
Only setting of value types got worse but it is not common usage of PropertyBag - in most cases of usage it stores reference types.